### PR TITLE
feat: 아파트 매물 추천을 위한 기능 추가

### DIFF
--- a/src/main/java/com/find/doongji/recommend/RecommendController.java
+++ b/src/main/java/com/find/doongji/recommend/RecommendController.java
@@ -1,0 +1,37 @@
+package com.find.doongji.recommend;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+
+@RestController
+@RequestMapping("/api/v1/recommend")
+public class RecommendController {
+
+    @PostMapping("/search")
+    public ResponseEntity<?> findSimilar(@RequestParam("query") String query, @RequestParam(value = "top_k", defaultValue = "16384") int topK) {
+        try {
+            String fastApiUrl = "http://localhost:8001/find_similar";
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            String requestBody = String.format("{\"query\": \"%s\", \"top_k\": %d}", query, topK);
+
+            HttpEntity<String> requestEntity = new HttpEntity<>(requestBody, headers);
+
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<String> response = restTemplate.postForEntity(fastApiUrl, requestEntity, String.class);
+
+            return ResponseEntity.ok(response.getBody());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- 아파트 매물 추천을 위한 기능 필요

## 📝작업 내용

- FastAPI 연동
- 사용자 입력 쿼리를 통해 리뷰 데이터 기반으로 유사 매물을 추천해주는 기능 구현


## 💬리뷰 요구사항

- top_k 기본값(16384)은 현재 milvus에 저장된 임베딩 벡터 수입니다. 유동적으로 변화하게 하는 방법이 있을지 검토해주세요.