### PR TITLE
fix: 쿼리 검색이 아닌 경우 내역 저장 방지합니다

### DIFF
--- a/src/main/java/com/find/doongji/listing/service/BasicListingService.java
+++ b/src/main/java/com/find/doongji/listing/service/BasicListingService.java
@@ -45,11 +45,7 @@ public class BasicListingService implements ListingService {
 
     @Override
     public void addListing(ListingCreateRequest request, MultipartFile image) throws Exception {
-
-        // TODO: 이미지 분류는 FastAPI 서버로 하기 때문에 ClassificationClient를 제거하고 FileUploader로 대체해야 함
-
         String username = SecurityContextHolder.getContext().getAuthentication().getName();
-
         List<AddressMappingResponse> addressMappings = addressRepository.selectAddressMappingByRoadAddress(request.getRoadAddress());
 
         List<Long> danjiIds = new ArrayList<>();

--- a/src/main/java/com/find/doongji/search/service/BasicSearchService.java
+++ b/src/main/java/com/find/doongji/search/service/BasicSearchService.java
@@ -128,7 +128,7 @@ public class BasicSearchService implements SearchService {
 
 
     private void trackSearchHistory(SearchRequest searchRequest) {
-        if (authService.isAuthenticated()) {
+        if (authService.isAuthenticated() && searchRequest.getQuery() != null) {
             String username = SecurityContextHolder.getContext().getAuthentication().getName();
             historyService.addHistory(new HistoryRequest(username, searchRequest.getQuery()));
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #14 

## 📝작업 내용

- 쿼리 검색이 아닌 경우 히스토리가 저장되지 않도록 로직 수정
- 기존 로직에서 모든 검색 내역이 저장되던 문제를 해결
