### PR TITLE
fix: Listing response에 isOptical 필드 추가합니다

### DIFF
--- a/src/main/java/com/find/doongji/listing/payload/response/ListingResponse.java
+++ b/src/main/java/com/find/doongji/listing/payload/response/ListingResponse.java
@@ -13,6 +13,8 @@ public class ListingResponse {
     private String username;
 
     private String imagePath;
+    private int isOptical;
+
     private String oldAddress;
     private String roadAddress;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

closes 15

## 📝작업 내용

isOptical 필드 추가:
- Listing API의 응답 데이터에 isOptical 필드를 추가.
- 이 필드는 Optical 여부를 나타내는 int 값으로 설정됩니다.

