### PR TITLE
Feature/11 like

### DIFF
--- a/src/main/java/com/find/doongji/auth/config/SecurityConfig.java
+++ b/src/main/java/com/find/doongji/auth/config/SecurityConfig.java
@@ -58,6 +58,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/listing/**").hasRole("SELLER")
                         .requestMatchers(HttpMethod.GET, "/api/v1/listing/**").permitAll()
 
+                        // like
+                        .requestMatchers(HttpMethod.POST, "/api/v1/search/result/**/like").authenticated()
+
                         // everything else
                         .anyRequest().permitAll())
                 .sessionManagement(

--- a/src/main/java/com/find/doongji/danji/repository/DanjiRepository.java
+++ b/src/main/java/com/find/doongji/danji/repository/DanjiRepository.java
@@ -33,5 +33,5 @@ public interface DanjiRepository {
      * @param aptNm
      * @return
      */
-    DanjiCode selectByAptNm(@Param("aptNm") String aptNm);
+    List<DanjiCode> selectByAptNm(@Param("aptNm") String aptNm);
 }

--- a/src/main/java/com/find/doongji/like/controller/BasicLikeController.java
+++ b/src/main/java/com/find/doongji/like/controller/BasicLikeController.java
@@ -4,7 +4,6 @@ import com.find.doongji.like.service.LikeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/find/doongji/like/controller/BasicLikeController.java
+++ b/src/main/java/com/find/doongji/like/controller/BasicLikeController.java
@@ -1,0 +1,4 @@
+package com.find.doongji.like.controller;
+
+public class BasicLikeController {
+}

--- a/src/main/java/com/find/doongji/like/controller/BasicLikeController.java
+++ b/src/main/java/com/find/doongji/like/controller/BasicLikeController.java
@@ -1,4 +1,32 @@
 package com.find.doongji.like.controller;
 
-public class BasicLikeController {
+import com.find.doongji.like.service.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class BasicLikeController implements LikeController {
+
+    private final LikeService likeService;
+
+    @Override
+    @PostMapping("/search/result/{aptSeq}/like")
+    public ResponseEntity<?> toggleLike(@PathVariable String aptSeq) {
+
+        try {
+            likeService.toggleLike(aptSeq);
+            return ResponseEntity.status(HttpStatus.CREATED).body("Successfully toggled like for aptSeq: " + aptSeq);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.badRequest().body("An error occurred while toggling like for aptSeq: " + aptSeq);
+        }
+    }
 }

--- a/src/main/java/com/find/doongji/like/controller/LikeController.java
+++ b/src/main/java/com/find/doongji/like/controller/LikeController.java
@@ -1,4 +1,9 @@
 package com.find.doongji.like.controller;
 
-public class LikeController {
+import org.springframework.http.ResponseEntity;
+
+public interface LikeController {
+
+    ResponseEntity<?> toggleLike(String aptSeq);
+
 }

--- a/src/main/java/com/find/doongji/like/controller/LikeController.java
+++ b/src/main/java/com/find/doongji/like/controller/LikeController.java
@@ -1,0 +1,4 @@
+package com.find.doongji.like.controller;
+
+public class LikeController {
+}

--- a/src/main/java/com/find/doongji/like/repository/LikeRepository.java
+++ b/src/main/java/com/find/doongji/like/repository/LikeRepository.java
@@ -1,0 +1,4 @@
+package com.find.doongji.like.repository;
+
+public interface LikeRepository {
+}

--- a/src/main/java/com/find/doongji/like/repository/LikeRepository.java
+++ b/src/main/java/com/find/doongji/like/repository/LikeRepository.java
@@ -1,4 +1,13 @@
 package com.find.doongji.like.repository;
 
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
 public interface LikeRepository {
+
+    void toggleLike(@Param("username") String username, @Param("aptSeq") String aptSeq);
+
+    int selectLike(@Param("username")String username, @Param("aptSeq")String aptSeq);
+
 }

--- a/src/main/java/com/find/doongji/like/service/BasicLikeService.java
+++ b/src/main/java/com/find/doongji/like/service/BasicLikeService.java
@@ -1,5 +1,6 @@
 package com.find.doongji.like.service;
 
+import com.find.doongji.auth.service.AuthService;
 import com.find.doongji.like.repository.LikeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
@@ -12,11 +13,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class BasicLikeService implements LikeService {
 
     private final LikeRepository likeRepository;
+    private final AuthService authService;
 
     @Override
     @Transactional
     public void toggleLike(String aptSeq) throws AccessDeniedException {
-        if (!isLoggedIn()) {
+
+        validateRequest(aptSeq);
+        if (!authService.isAuthenticated()) {
             throw new AccessDeniedException("You must be logged in to like.");
         }
 
@@ -27,7 +31,9 @@ public class BasicLikeService implements LikeService {
     @Override
     @Transactional(readOnly = true)
     public int viewLike(String aptSeq) {
-        if (!isLoggedIn()) {
+
+        validateRequest(aptSeq);
+        if (!authService.isAuthenticated()) {
             return 0;
         }
 
@@ -35,8 +41,9 @@ public class BasicLikeService implements LikeService {
         return likeRepository.selectLike(username, aptSeq);
     }
 
-    private boolean isLoggedIn() {
-        return SecurityContextHolder.getContext().getAuthentication() != null && SecurityContextHolder.getContext().getAuthentication().isAuthenticated()
-                && !"anonymousUser".equals(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+    private void validateRequest(String aptSeq) {
+        if (aptSeq == null || aptSeq.trim().isEmpty()) {
+            throw new IllegalArgumentException("AptSeq must not be null or empty");
+        }
     }
 }

--- a/src/main/java/com/find/doongji/like/service/BasicLikeService.java
+++ b/src/main/java/com/find/doongji/like/service/BasicLikeService.java
@@ -27,7 +27,7 @@ public class BasicLikeService implements LikeService {
 
     @Override
     @Transactional(readOnly = true)
-    public int isLiked(String aptSeq) {
+    public int viewLike(String aptSeq) {
         if (!isLoggedIn()) {
             return 0;
         }

--- a/src/main/java/com/find/doongji/like/service/BasicLikeService.java
+++ b/src/main/java/com/find/doongji/like/service/BasicLikeService.java
@@ -1,0 +1,4 @@
+package com.find.doongji.like.service;
+
+public class BasicLikeService {
+}

--- a/src/main/java/com/find/doongji/like/service/BasicLikeService.java
+++ b/src/main/java/com/find/doongji/like/service/BasicLikeService.java
@@ -2,11 +2,10 @@ package com.find.doongji.like.service;
 
 import com.find.doongji.like.repository.LikeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.nio.file.AccessDeniedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/find/doongji/like/service/BasicLikeService.java
+++ b/src/main/java/com/find/doongji/like/service/BasicLikeService.java
@@ -1,4 +1,43 @@
 package com.find.doongji.like.service;
 
-public class BasicLikeService {
+import com.find.doongji.like.repository.LikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.file.AccessDeniedException;
+
+@Service
+@RequiredArgsConstructor
+public class BasicLikeService implements LikeService {
+
+    private final LikeRepository likeRepository;
+
+    @Override
+    @Transactional
+    public void toggleLike(String aptSeq) throws AccessDeniedException {
+        if (!isLoggedIn()) {
+            throw new AccessDeniedException("You must be logged in to like.");
+        }
+
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        likeRepository.toggleLike(username, aptSeq);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public int isLiked(String aptSeq) {
+        if (!isLoggedIn()) {
+            return 0;
+        }
+
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        return likeRepository.selectLike(username, aptSeq);
+    }
+
+    private boolean isLoggedIn() {
+        return SecurityContextHolder.getContext().getAuthentication() != null && SecurityContextHolder.getContext().getAuthentication().isAuthenticated()
+                && !"anonymousUser".equals(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+    }
 }

--- a/src/main/java/com/find/doongji/like/service/LikeService.java
+++ b/src/main/java/com/find/doongji/like/service/LikeService.java
@@ -1,0 +1,4 @@
+package com.find.doongji.like.service;
+
+public interface LikeService {
+}

--- a/src/main/java/com/find/doongji/like/service/LikeService.java
+++ b/src/main/java/com/find/doongji/like/service/LikeService.java
@@ -1,6 +1,6 @@
 package com.find.doongji.like.service;
 
-import java.nio.file.AccessDeniedException;
+import org.springframework.security.access.AccessDeniedException;
 
 public interface LikeService {
 

--- a/src/main/java/com/find/doongji/like/service/LikeService.java
+++ b/src/main/java/com/find/doongji/like/service/LikeService.java
@@ -1,4 +1,18 @@
 package com.find.doongji.like.service;
 
+import java.nio.file.AccessDeniedException;
+
 public interface LikeService {
+
+    /**
+     * 좋아요 생성 (좋아요 존재 시 삭제)
+     * @param aptSeq
+     */
+    void toggleLike(String aptSeq) throws AccessDeniedException;
+
+    /**
+     * 좋아요 여부 조회
+     * @param aptSeq
+     */
+    int isLiked(String aptSeq);
 }

--- a/src/main/java/com/find/doongji/like/service/LikeService.java
+++ b/src/main/java/com/find/doongji/like/service/LikeService.java
@@ -14,5 +14,5 @@ public interface LikeService {
      * 좋아요 여부 조회
      * @param aptSeq
      */
-    int isLiked(String aptSeq);
+    int viewLike(String aptSeq);
 }

--- a/src/main/java/com/find/doongji/search/payload/response/SearchDetailResponse.java
+++ b/src/main/java/com/find/doongji/search/payload/response/SearchDetailResponse.java
@@ -1,0 +1,4 @@
+package com.find.doongji.search.payload.response;
+
+public class SearchDetailResponse {
+}

--- a/src/main/java/com/find/doongji/search/payload/response/SearchDetailResponse.java
+++ b/src/main/java/com/find/doongji/search/payload/response/SearchDetailResponse.java
@@ -1,4 +1,17 @@
 package com.find.doongji.search.payload.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SearchDetailResponse {
+
+    private SearchResult searchResult;
+    private int isLiked;
+
 }

--- a/src/main/java/com/find/doongji/search/payload/response/SearchResponse.java
+++ b/src/main/java/com/find/doongji/search/payload/response/SearchResponse.java
@@ -14,4 +14,5 @@ import lombok.NoArgsConstructor;
 public class SearchResponse {
     private SimilarityScore similarityScore;
     private AptInfo aptInfo;
+    private int isLiked;
 }

--- a/src/main/java/com/find/doongji/search/service/SearchService.java
+++ b/src/main/java/com/find/doongji/search/service/SearchService.java
@@ -1,6 +1,7 @@
 package com.find.doongji.search.service;
 
 import com.find.doongji.search.payload.request.SearchRequest;
+import com.find.doongji.search.payload.response.SearchDetailResponse;
 import com.find.doongji.search.payload.response.SearchResponse;
 import com.find.doongji.search.payload.response.SearchResult;
 
@@ -10,5 +11,5 @@ public interface SearchService {
 
     List<SearchResponse> search(SearchRequest searchRequest) throws Exception;
 
-    SearchResult viewSearched(String aptSeq) throws Exception;
+    SearchDetailResponse viewSearched(String aptSeq) throws Exception;
 }

--- a/src/main/resources/db/mapper/like.xml
+++ b/src/main/resources/db/mapper/like.xml
@@ -17,11 +17,14 @@
 
     <!-- 좋아요 여부 조회 -->
     <select id="selectLike" resultType="java.lang.Integer">
-        SELECT liked
+        SELECT COALESCE(
+        (SELECT liked
         FROM likes
-        WHERE username = #{username}
-        AND apt_seq = #{aptSeq};
+        WHERE username = #{username} AND apt_seq = #{aptSeq}
+        ), 0) AS liked;
     </select>
+
+
 
 
 

--- a/src/main/resources/db/mapper/like.xml
+++ b/src/main/resources/db/mapper/like.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.find.doongji.like.repository.LikeRepository">
+
+
+    <!-- 좋아요 등록 -->
+    <update id="toggleLike">
+        INSERT INTO likes (username, apt_seq, liked, created_at)
+        VALUES (#{username}, #{aptSeq}, 1, CURRENT_TIMESTAMP)
+        ON DUPLICATE KEY UPDATE
+        liked = 1 - liked,
+        created_at = CURRENT_TIMESTAMP;
+    </update>
+
+    <!-- 좋아요 여부 조회 -->
+    <select id="selectLike" resultType="java.lang.Integer">
+        SELECT liked
+        FROM likes
+        WHERE username = #{username}
+        AND apt_seq = #{aptSeq};
+    </select>
+
+
+
+</mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #19 

## 📝작업 내용

#### 1. **좋아요 기능 추가**
- `/api/v1/search/result/{aptSeq}/like` 엔드포인트 구현
- 사용자가 특정 검색 결과 항목에 대해 좋아요를 토글할 수 있도록 기능 구현
- 좋아요 여부는 likes 테이블의 liked 컬럼(0/1)로 관리


#### 2. 좋아요 여부 조회 기능

- 사용자가 특정 항목을 이미 좋아요했는지 확인 가능
- 없는 경우 기본값으로 0을 반환하도록 SQL 쿼리 수정



## 💬리뷰 요구사항(선택)

#### 1. toggleLike 메서드의 SQL 쿼리 최적화 가능성:

`ON DUPLICATE KEY UPDATE` 쿼리 외에 더 효율적인 방법이 있을까요?

#### 2. selectLike 쿼리에서 COALESCE를 사용하는 방식의 가독성:

결과를 항상 0 또는 1로 반환하는 현재 구현이 적절한지, 더 나은 방식이 있을지 고민됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a "like" functionality for search results, allowing authenticated users to like or unlike apartments.
  - Enhanced search results to include like status for each apartment.

- **Updates**
  - Modified the search response structure to provide detailed information, including like status.
  - Expanded the capabilities of the search service to handle multiple records and improved response handling.

- **Bug Fixes**
  - Improved security by ensuring only authenticated users can access the like functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->