### PR TITLE
fix: 사용자의 좋아요 목록을 조회하는 엔드포인트를 추가하고, Spring Security 이슈를 해결합니다

### DIFF
--- a/src/main/java/com/find/doongji/auth/config/SecurityConfig.java
+++ b/src/main/java/com/find/doongji/auth/config/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/listing/**").permitAll()
 
                         // like
-                        .requestMatchers(HttpMethod.POST, "/api/v1/search/result/**/like").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/like/**").authenticated()
 
                         // everything else
                         .anyRequest().permitAll())

--- a/src/main/java/com/find/doongji/like/controller/BasicLikeController.java
+++ b/src/main/java/com/find/doongji/like/controller/BasicLikeController.java
@@ -4,28 +4,35 @@ import com.find.doongji.like.service.LikeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/like")
 @RequiredArgsConstructor
 public class BasicLikeController implements LikeController {
 
     private final LikeService likeService;
 
     @Override
-    @PostMapping("/search/result/{aptSeq}/like")
+    @PostMapping("/{aptSeq}")
     public ResponseEntity<?> toggleLike(@PathVariable String aptSeq) {
-
         try {
             likeService.toggleLike(aptSeq);
             return ResponseEntity.status(HttpStatus.CREATED).body("Successfully toggled like for aptSeq: " + aptSeq);
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.badRequest().body("An error occurred while toggling like for aptSeq: " + aptSeq);
+        }
+    }
+
+    @Override
+    @GetMapping("/all")
+    public ResponseEntity<?> getAllLikes() {
+        try {
+            return ResponseEntity.ok(likeService.getAllLikes());
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.badRequest().body("An error occurred while retrieving all likes.");
         }
     }
 }

--- a/src/main/java/com/find/doongji/like/controller/LikeController.java
+++ b/src/main/java/com/find/doongji/like/controller/LikeController.java
@@ -6,4 +6,5 @@ public interface LikeController {
 
     ResponseEntity<?> toggleLike(String aptSeq);
 
+    ResponseEntity<?> getAllLikes();
 }

--- a/src/main/java/com/find/doongji/like/repository/LikeRepository.java
+++ b/src/main/java/com/find/doongji/like/repository/LikeRepository.java
@@ -3,6 +3,8 @@ package com.find.doongji.like.repository;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.util.List;
+
 @Mapper
 public interface LikeRepository {
 
@@ -10,4 +12,5 @@ public interface LikeRepository {
 
     int selectLike(@Param("username")String username, @Param("aptSeq")String aptSeq);
 
+    List<String> selectAllLikes(@Param("username") String username);
 }

--- a/src/main/java/com/find/doongji/like/service/BasicLikeService.java
+++ b/src/main/java/com/find/doongji/like/service/BasicLikeService.java
@@ -1,5 +1,7 @@
 package com.find.doongji.like.service;
 
+import com.find.doongji.apt.payload.response.AptInfo;
+import com.find.doongji.apt.repository.AptRepository;
 import com.find.doongji.auth.service.AuthService;
 import com.find.doongji.like.repository.LikeRepository;
 import lombok.RequiredArgsConstructor;
@@ -8,12 +10,16 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class BasicLikeService implements LikeService {
 
     private final LikeRepository likeRepository;
     private final AuthService authService;
+    private final AptRepository aptRepository;
 
     @Override
     @Transactional
@@ -39,6 +45,17 @@ public class BasicLikeService implements LikeService {
 
         String username = SecurityContextHolder.getContext().getAuthentication().getName();
         return likeRepository.selectLike(username, aptSeq);
+    }
+
+    @Override
+    public List<AptInfo> getAllLikes() {
+        if (!authService.isAuthenticated()) {
+            throw new AccessDeniedException("You must be logged in to view likes.");
+        }
+
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        List<String> likedAptSeq = likeRepository.selectAllLikes(username); // aptSeq list
+        return likedAptSeq.stream().map(aptRepository::selectAptInfoByAptSeq).collect(Collectors.toList());
     }
 
     private void validateRequest(String aptSeq) {

--- a/src/main/java/com/find/doongji/like/service/LikeService.java
+++ b/src/main/java/com/find/doongji/like/service/LikeService.java
@@ -1,6 +1,9 @@
 package com.find.doongji.like.service;
 
+import com.find.doongji.apt.payload.response.AptInfo;
 import org.springframework.security.access.AccessDeniedException;
+
+import java.util.List;
 
 public interface LikeService {
 
@@ -15,4 +18,9 @@ public interface LikeService {
      * @param aptSeq
      */
     int viewLike(String aptSeq);
+
+    /**
+     * 로그인한 사용자에 대한 모든 좋아요 조회
+     */
+    List<AptInfo>  getAllLikes();
 }

--- a/src/main/resources/db/mapper/like.xml
+++ b/src/main/resources/db/mapper/like.xml
@@ -24,7 +24,13 @@
         ), 0) AS liked;
     </select>
 
-
+    <!-- 좋아요 목록 조회 -->
+    <select id="selectAllLikes" resultType="string">
+        SELECT apt_seq
+        FROM likes
+        WHERE username = #{username}
+        AND liked = 1;
+    </select>
 
 
 


### PR DESCRIPTION

## 📝작업 내용

1. 사용자의 좋아요 목록을 조회하는 엔드포인트를 추가합니다
2. 기존의 엔드포인트를 수정합니다
3. Spring Security 접근권한 이슈를 해결합니다.
